### PR TITLE
Removed google ads snippet

### DIFF
--- a/modules/header.php
+++ b/modules/header.php
@@ -31,12 +31,4 @@
          ga("create", "UA-47286500-3", "auto");		
          ga("send", "pageview");		
    </script>		
-  		  
-   <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>		
-   <!-- ROTGMain -->		
-   <ins class="adsbygoogle"		
-        style="display:block"		
-        data-ad-client="ca-pub-4499070912220787"		
-        data-ad-slot="6092543559"		
-        data-ad-format="auto"></ins>
-
+  

--- a/modules/header.php
+++ b/modules/header.php
@@ -31,4 +31,4 @@
          ga("create", "UA-47286500-3", "auto");		
          ga("send", "pageview");		
    </script>		
-  
+


### PR DESCRIPTION
JS was failing to load and leaving a white space at the top of the page.
fixes #21 